### PR TITLE
results announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 PETRIC 2 has now concluded. Please check out the  [awards-and-results](https://github.com/SyneRBI/PETRIC2/wiki/Awards-and-results)!
 
-Recordings of the PETRIC 2 winners' presentations are available on [https://www.ccpsynerbi.ac.uk/petric2-airbi](https://www.ccpsynerbi.ac.uk/petric2-airbi)
+Recordings of the PETRIC 2 winners' presentations will be (are?) available on [https://www.ccpsynerbi.ac.uk/petric2-airbi](https://www.ccpsynerbi.ac.uk/petric2-airbi)
 
 ## What's the same?
 As with [the previous challenge (PETRIC1)](https://github.com/SyneRBI/PETRIC), the goal is to solve a maximum a-posteriori (MAP) estimate using a smoothed relative difference prior (RDP), reaching the target image quality as fast as possible.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 [![website](https://img.shields.io/badge/announcement-website-purple?logo=workplace&logoColor=white)](https://www.ccpsynerbi.ac.uk/events/petric2/)
 [![wiki](https://img.shields.io/badge/details-wiki-blue?logo=googledocs&logoColor=white)][wiki]
-[![register](https://img.shields.io/badge/participate-register-green?logo=ticktick&logoColor=white)][register]
-[![leaderboard](https://img.shields.io/badge/results-leaderboard-orange)][leaderboard]
-[![tensorboard](https://img.shields.io/badge/metrics-tensorboard-orange?logo=tensorflow&logoColor=white)][tensorboard]
+[![leaderboard](https://img.shields.io/badge/results-leaderboard-orange?logo=ticktick&logoColor=white)][leaderboard]
 [![discord](https://img.shields.io/badge/chat-discord-blue?logo=discord&logoColor=white)](https://discord.gg/Ayd72Aa4ry)
 
 ## Participating
 
-The organisers will provide GPU-enabled cloud runners which have access to larger private datasets for evaluation. To gain access, you must [register]. The organisers will then create a private team submission repository for you.
+PETRIC 2 has now concluded. Please check out the  [awards-and-results](https://github.com/SyneRBI/PETRIC2/wiki/Awards-and-results)!
 
-[register]: https://github.com/SyneRBI/PETRIC2/issues/new/choose
+Recordings of the PETRIC 2 winners' presentations are available on [https://www.ccpsynerbi.ac.uk/petric2-airbi](https://www.ccpsynerbi.ac.uk/petric2-airbi)
 
 ## What's the same?
 As with [the previous challenge (PETRIC1)](https://github.com/SyneRBI/PETRIC), the goal is to solve a maximum a-posteriori (MAP) estimate using a smoothed relative difference prior (RDP), reaching the target image quality as fast as possible.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 PETRIC 2 has now concluded. Please check out the  [awards-and-results](https://github.com/SyneRBI/PETRIC2/wiki/Awards-and-results)!
 
-Recordings of the PETRIC 2 winners' presentations will be (are?) available on [https://www.ccpsynerbi.ac.uk/petric2-airbi](https://www.ccpsynerbi.ac.uk/petric2-airbi)
+Recordings of the PETRIC 2 winners' presentations will be (are?) available on [https://www.ccpsynerbi.ac.uk/petric2-winners](https://www.ccpsynerbi.ac.uk/petric2-winnersi)
 
 ## What's the same?
 As with [the previous challenge (PETRIC1)](https://github.com/SyneRBI/PETRIC), the goal is to solve a maximum a-posteriori (MAP) estimate using a smoothed relative difference prior (RDP), reaching the target image quality as fast as possible.


### PR DESCRIPTION
- [ ] @paskino: create https://www.ccpsynerbi.ac.uk/petric2-winners based on https://www.ccpsynerbi.ac.uk/petric-workshop
- [x] @casperdcl: create https://github.com/SyneRBI/PETRIC2/wiki/Awards-and-results based on https://github.com/SyneRBI/PETRIC/wiki/Awards-and-results
  + [x] @KrisThielemans: get/add team photos
  + [ ] @paskino: summarise algorithm approaches
- [x] @casperdcl update README (this PR #85)
  + [x] update https://github.com/SyneRBI/PETRIC2/wiki based on https://github.com/SyneRBI/PETRIC/wiki
  + [x] update https://github.com/SyneRBI/PETRIC2/wiki/Recent-Updates

---

https://petric.tomography.stfc.ac.uk/2/leaderboard

1. Speedy (Hok Shing Wong, Margaret Duff, Georg Schramm, Matthias Ehrhardt)
    - [psv](https://github.com/SyneRBI/PETRIC2-Speedy/tree/psv) (1st overall)
    - [pd1](https://github.com/SyneRBI/PETRIC2-Speedy/tree/pd1)
    - [pd2](https://github.com/SyneRBI/PETRIC2-Speedy/tree/pd2)
2. PATRIC (Patrick Fahy, Zeljko Kereta, Mohammad Golbabaee, Matthias Ehrhardt)
    - [kernels](https://github.com/SyneRBI/PETRIC2-PATRIC/tree/kernels) (3rd overall)
    - [kernelVOIs](https://github.com/SyneRBI/PETRIC2-PATRIC/tree/kernelVOIs)
3. Beavers (Maxime Toussaint, Simon Stute, Nasrin Taheri)
    - [qntrnar_utb3](https://github.com/SyneRBI/PETRIC2-Beavers/tree/qntrnar_utb3) (5th overall)
    - [qntrnar_SI_prov](https://github.com/SyneRBI/PETRIC2-Beavers/tree/qntrnar_SI_prov)
    - [pwals_SI_prov](https://github.com/SyneRBI/PETRIC2-Beavers/tree/pwals_SI_prov)

